### PR TITLE
fix(rust-toolchain-gnu): correct the pattern of extract_dir in autoup…

### DIFF
--- a/bucket/rust-toolchain-gnu.json
+++ b/bucket/rust-toolchain-gnu.json
@@ -25,7 +25,7 @@
                 "rust-src-1.70.0\\rust-src",
                 "rustfmt-1.70.0-x86_64-pc-windows-gnu\\rustfmt-preview",
                 "clippy-1.70.0-x86_64-pc-windows-gnu\\clippy-preview",
-                "rust-analyzer-1.70.0-x86_64-pc-windows-gnu\\rust-analyzer"
+                "rust-analyzer-1.70.0-x86_64-pc-windows-gnu\\rust-analyzer-preview"
             ]
         }
     },

--- a/bucket/rust-toolchain-gnu.json
+++ b/bucket/rust-toolchain-gnu.json
@@ -56,7 +56,7 @@
                     "rust-src-$version\\rust-src",
                     "rustfmt-$version-x86_64-pc-windows-gnu\\rustfmt-preview",
                     "clippy-$version-x86_64-pc-windows-gnu\\clippy-preview",
-                    "rust-analyzer-$version-x86_64-pc-windows-gnu\\rust-analyzer"
+                    "rust-analyzer-$version-x86_64-pc-windows-gnu\\rust-analyzer-preview"
                 ]
             }
         },


### PR DESCRIPTION
…date

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
